### PR TITLE
Added routes

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,15 @@
 import 'package:flutter/material.dart';
+import 'package:world_time_app/pages/choose_location.dart';
 import 'package:world_time_app/pages/home.dart';
+import 'package:world_time_app/pages/loading.dart';
 
 void main() {
   runApp(MaterialApp(
-    home: Home(),
-    ));
+    initialRoute: '/home',
+    routes: {
+      '/': (context) => Loading(),
+      '/home': (context) => Home(),
+      '/location': (context) => ChooseLocation(),
+    },
+  ));
 }


### PR DESCRIPTION
* To enable switching between different screens we have 3 routes

* Initial route is loading screen for production but for testing and during the development phase '/home' will be the initial route

* Set the initialRoute to '/home' which points to Home() widget